### PR TITLE
添加SE3331 SE3353课程参考代码 以及修改SE2301 SE127仓库链接

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ ___
 * [rennsax-2021](https://github.com/rennsax/ICS-lab)
 * [ghazariann-2021](https://github.com/ghazariann/SJTU-computer-system-fundamentals)
 * [GiggleWang-2022](https://github.com/GiggleWang/ICS_lab)
-* [Kiwi-2022](https://github.com/kiwi142857/SJTU-SE2302-ICS)
+* [Kiwi-2022](https://github.com/kiwi142857/SE2301-SE2302-ICS)
 
 ### Database System-Book Store
 
@@ -337,7 +337,7 @@ The following is the result of searching "6.858 Computer Systems Security site:g
 * [rennsax-2021](https://github.com/rennsax/SE2308-QBasic)
 * [ghazariann-2021](https://github.com/ghazariann/SJTU-software-engineering-practice)
 * [GiggleWang-2022](https://github.com/GiggleWang/SJTU-SEP-code)
-* [Kiwi-2022](https://github.com/kiwi142857/SJTU-SEP-Project)
+* [Kiwi-2022](https://github.com/kiwi142857/SE1301-SEP-Project)
 * [Ayanami-2023-QLink](https://github.com/Ayanami1314/QLink)
 * [Ayanami-2023-QBasic](https://github.com/Ayanami1314/qbasic)
 * [overji-2023](https://github.com/overji/SJTU-SE-SEP2024)
@@ -369,7 +369,7 @@ The following is the result of searching "6.858 Computer Systems Security site:g
 * [Ayanami-2022](https://github.com/Ayanami1314/LSM-KV)
 * [Creeper-2022](https://github.com/creeper12356/LSM-KV)
 * [GiggleWang-2022](https://github.com/GiggleWang/LSM_Tree)
-* [Kiwi-2022](https://github.com/kiwi142857/SJTU-SE2322-ADS)
+* [Kiwi-2022](https://github.com/kiwi142857/SE2322-ADS)
 
 ### Cloud Operating System
 

--- a/readme.md
+++ b/readme.md
@@ -242,6 +242,7 @@ ___
 * [ghazariann-2021](https://github.com/ghazariann/SJTU-compilers)
 * [rennsax-2021](https://github.com/rennsax/SE3355-Tiger-Compiler)
 * [EdogawaAi-2022](https://github.com/EdogawaAi/compilers-2024.git)
+* [Kiwi-2022](https://github.com/kiwi142857/SE3355-Compiler-Lab)
 
 ### Programming Languages
 

--- a/readme.md
+++ b/readme.md
@@ -149,7 +149,8 @@ ___
 * [GiggleWang-backend-2022](https://github.com/GiggleWang/web-bookstore-backend)
 ### CSE (yfs lab, MIT 6.033)
 
-> SE227 - 计算机系统工程
+> 2021 级及以前：SE227 - 计算机系统工程
+> 2022 级及以后：SE3331 - 计算机系统基础
 
 * [kingFighter-2011](https://github.com/kingFighter/cse-lab-2013-fall)
 * [Azard-2012](https://github.com/Azard/SE227-CSE-lab)

--- a/readme.md
+++ b/readme.md
@@ -149,8 +149,8 @@ ___
 * [GiggleWang-backend-2022](https://github.com/GiggleWang/web-bookstore-backend)
 ### CSE (yfs lab, MIT 6.033)
 
-> 2021 级及以前：SE227 - 计算机系统工程
-> 2022 级及以后：SE3331 - 计算机系统基础
+> 2019 级及以前：SE227 - 计算机系统工程
+> 2020 级及以后：SE3331 - 计算机系统工程
 
 * [kingFighter-2011](https://github.com/kingFighter/cse-lab-2013-fall)
 * [Azard-2012](https://github.com/Azard/SE227-CSE-lab)

--- a/readme.md
+++ b/readme.md
@@ -262,6 +262,7 @@ ___
 * [PeterTheSparrow-2021](https://github.com/PeterTheSparrow/SE3353-Architecture-of-Enterprise-Applications-2023Autumn-SJTU-notes)
 * [Ayanami-2022-homeworks&notes](https://ayanami1314.github.io/docs/%E5%BA%94%E7%94%A8%E7%B3%BB%E7%BB%9F%E4%BD%93%E7%B3%BB%E6%9E%B6%E6%9E%84/%E4%BD%9C%E4%B8%9A/hw1-impl)
 * [bangdreammygo-2022](https://github.com/bangdreammygo/SJTU--SE3353)
+* [Kiwi-2022](https://github.com/kiwi142857/SE2321-SE3353-Arch)
 
 ### Digital Component Design
 

--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,7 @@ ___
 * [LFsoul0-2019](https://github.com/LFsoul0/CSE_Labs)
 * [ghazariann-2021](https://github.com/ghazariann/SJTU-computer-system-engineering)
 * [EdogawaAi-2022](https://github.com/EdogawaAi/SE3331-chfs.git)
+* [Kiwi-2022](https://github.com/kiwi142857/SE3331-CSE-Chfs)
 
 ### OS (jos lab, MIT 6.828 | chcore lab)
 


### PR DESCRIPTION
1. 修改SE2301 SE127仓库链接至新仓库名称
2. 添加CSE SE3331课程代码参考仓库
3. 添加CSE SE227课号变更情况 SE227 -> SE3331
4. 添加SE3353课程代码参考仓库